### PR TITLE
Use AWS NodeJS SDK instead of AWS CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "author": "David Boyne",
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/client-eventbridge": "^3.13.1",
+    "@aws-sdk/client-schemas": "^3.13.1",
     "cheerio": "^1.0.0-rc.6",
     "dotenv": "^8.2.0",
     "fs-extra": "^9.1.0",

--- a/src/utils/aws.js
+++ b/src/utils/aws.js
@@ -1,33 +1,38 @@
-import exec from './exec'
+const { EventBridge } = require('@aws-sdk/client-eventbridge')
+const { Schemas } = require('@aws-sdk/client-schemas')
 
-export const getTargetsForEventsOnEventBridge = async () => {
+const schemas = new Schemas()
+const eventbridge = new EventBridge()
+
+export const getTargetsForEventsOnEventBridge = async (eventBusName) => {
   console.log('Getting targets for events....')
-  const targets = await exec(
-    `aws events list-rules --event-bus-name ${process.env.EVENT_BUS_NAME} --region ${process.env.REGION}`,
-    true
-  )
-  const targetsForEvents = JSON.parse(targets.stdout)
-  return buildTargets(targetsForEvents)
+  const targetsForEvents = await eventbridge.listRules({EventBusName: eventBusName})
+  return buildTargets(targetsForEvents.Rules)
 }
 
-export const getAllSchemasAsJSONSchema = async (schemaList) => {
+export const getAllSchemas = async (registryName) => {
+  return await schemas.listSchemas({RegistryName: registryName})
+}
+
+export const getAllSchemasAsJSONSchema = async (registryName, schemaList) => {
   return schemaList.map(async (schema) => {
-    return exec(
-      `aws schemas export-schema --registry-name ${process.env.SCHEMA_REGISTRY_NAME} --region ${process.env.REGION} --schema-name ${schema.SchemaName} --type JSONSchemaDraft4`,
-      true
-    )
+    return schemas.exportSchema({
+      RegistryName: registryName,
+      SchemaName: schema.SchemaName,
+      Type: 'JSONSchemaDraft4'
+    })
   })
 }
 
-export const hydrateSchemasWithAdditionalOpenAPIData = async (schemas) => {
-  return schemas.map(async (rawSchema) => {
+export const hydrateSchemasWithAdditionalOpenAPIData = async (registryName, schemaList) => {
+  return schemaList.map(async (rawSchema) => {
     const schema = buildSchema(rawSchema)
 
     // get the schema as open API too, as its has more metadata we might find useful.
-    const openAPISchema = await exec(
-      `aws schemas describe-schema --registry-name ${process.env.SCHEMA_REGISTRY_NAME} --schema-name ${schema.SchemaName} --region ${process.env.REGION}`,
-      true
-    )
+    const openAPISchema = await schemas.describeSchema({
+      RegistryName: registryName,
+      SchemaName: schema.SchemaName,
+    })
     const schemaAsOpenAPI = buildSchema(openAPISchema)
 
     const { LastModified, SchemaArn, SchemaVersion, Tags, VersionCreatedDate } = schemaAsOpenAPI
@@ -44,12 +49,7 @@ export const hydrateSchemasWithAdditionalOpenAPIData = async (schemas) => {
 }
 
 export const buildSchema = (rawSchema) => {
-  const schemaDescription = JSON.parse(rawSchema.stdout)
-  const { Content, ...schema } = schemaDescription
-  return {
-    Content: JSON.parse(Content),
-    ...schema,
-  }
+  return { ...rawSchema, Content: JSON.parse(rawSchema.Content) }
 }
 
 export const buildTargets = ({ Rules = [] }) => {


### PR DESCRIPTION
Using the SDK will allow users to manage their AWS credentials using their preferred configuration.

By setting `AWS_SDK_LOAD_CONFIG=1` and `AWS_PROFILE=<profilename>` you can avoid peppering credentials in .env files