### PR TITLE
fix: fixing issue with regions not being read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ src/parsers/slate/build
 
 # Flow Ignores
 src/parsers/flow/src/lib/data/registry.json
+
+data/*

--- a/src/utils/aws.js
+++ b/src/utils/aws.js
@@ -1,8 +1,14 @@
+const path = require('path')
 const { EventBridge } = require('@aws-sdk/client-eventbridge')
 const { Schemas } = require('@aws-sdk/client-schemas')
+require('dotenv').config({ path: path.resolve(process.cwd(), '.env') })
 
-const schemas = new Schemas()
-const eventbridge = new EventBridge()
+const schemas = new Schemas({
+  region: process.env.REGION,
+})
+const eventbridge = new EventBridge({
+  region: process.env.REGION,
+})
 
 export const getTargetsForEventsOnEventBridge = async (eventBusName) => {
   const targetsForEvents = await eventbridge.listRules({ EventBusName: eventBusName })


### PR DESCRIPTION
After talking to @bls20AWS we found a few issues with the `REGION` not being used by the application and the SDK defaulting to its own default region.

This fix now uses the region as expected.