### PR TITLE
fix: filter only non cron rules

### DIFF
--- a/src/utils/aws.js
+++ b/src/utils/aws.js
@@ -58,7 +58,7 @@ export const buildSchema = (rawSchema) => {
 }
 
 export const buildTargets = (busRules) => {
-  return busRules.reduce((rules, rule) => {
+  return busRules.filter(busRule => busRule.EventPattern !== undefined).reduce((rules, rule) => {
     const eventPattern = JSON.parse(rule.EventPattern)
     const detailType = eventPattern['detail-type'] || []
     detailType.forEach((detail) => {


### PR DESCRIPTION
If An Aws account consists of cron jobs, these rules don't have `EventPattern` defined.

<img width="1137" alt="Screenshot 2022-09-18 at 5 02 56 PM" src="https://user-images.githubusercontent.com/30518725/190900042-4e860dfa-1a48-4baa-b0d6-fdeb4b27e06a.png">
